### PR TITLE
Expose `ParseAndKeepRawInput`, and `CountryCodeSource`

### DIFF
--- a/cbits/phone-numbers.cc
+++ b/cbits/phone-numbers.cc
@@ -28,6 +28,14 @@ extern "C" int _c_phone_number_util_parse(void *util_instance, char *number_str,
               std::string(region_str, region_len), (PhoneNumber *)phone_no);
 }
 
+extern "C" int _c_phone_number_util_parse_and_keep_raw_input(void *util_instance, char *number_str,
+                                          size_t number_len, char *region_str,
+                                          size_t region_len, void *phone_no) {
+  return ((PhoneNumberUtil *)util_instance)
+      ->ParseAndKeepRawInput(std::string(number_str, number_len),
+              std::string(region_str, region_len), (PhoneNumber *)phone_no);
+}
+
 extern "C" bool _c_phone_number_has_country_code(void *phone_no) {
   return ((PhoneNumber *)phone_no)->has_country_code();
 }
@@ -93,4 +101,18 @@ extern "C" bool _c_phone_number_util_is_valid_number(
     void *util_instance, void *phone_no) {
   return ((PhoneNumberUtil *)util_instance)
       ->IsValidNumber(*((PhoneNumber *)phone_no));
+}
+
+// The CountryCodeSource enum comes from phonenumber.proto
+// so we need to convert it manually
+extern "C" int _c_phone_number_get_country_code_source(
+    void *phone_no) {
+  switch (((PhoneNumber *)phone_no)->country_code_source()) {
+    case PhoneNumber::FROM_NUMBER_WITH_PLUS_SIGN: return FROM_NUMBER_WITH_PLUS_SIGN;
+    case PhoneNumber::FROM_NUMBER_WITH_IDD: return FROM_NUMBER_WITH_IDD;
+    case PhoneNumber::FROM_NUMBER_WITHOUT_PLUS_SIGN: return FROM_NUMBER_WITHOUT_PLUS_SIGN;
+    case PhoneNumber::FROM_DEFAULT_COUNTRY: return FROM_DEFAULT_COUNTRY;
+    case PhoneNumber::UNSPECIFIED: 
+    default: return UNSPECIFIED;
+  }
 }

--- a/include/c-phone-numbers.h
+++ b/include/c-phone-numbers.h
@@ -63,6 +63,14 @@ enum ErrorType {
                 TOO_LONG_NSN,  // TOO_LONG in the java version.
 };
 
+enum CountryCodeSource {
+    UNSPECIFIED,
+    FROM_NUMBER_WITH_PLUS_SIGN,
+    FROM_NUMBER_WITH_IDD,
+    FROM_NUMBER_WITHOUT_PLUS_SIGN,
+    FROM_DEFAULT_COUNTRY,
+};
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/lib/Data/PhoneNumber/FFI.chs
+++ b/lib/Data/PhoneNumber/FFI.chs
@@ -6,12 +6,14 @@ module Data.PhoneNumber.FFI (
     PhoneNumberType(..),
     PhoneNumberFormat(..),
     PhoneNumberParseError(..),
+    CountryCodeSource(..),
 
     -- * Parsing and utility
     c_phone_number_ctor,
     c_phone_number_dtor,
     c_phone_number_util_get_instance,
     c_phone_number_util_parse,
+    c_phone_number_util_parse_and_keep_raw_input,
     c_phone_number_convert_alpha_characters_in_number,
 
     -- * Accessors / metadata
@@ -23,6 +25,7 @@ module Data.PhoneNumber.FFI (
     c_phone_number_get_extension,
     c_phone_number_get_number_type,
     c_phone_number_get_formatted,
+    c_phone_number_get_country_code_source,
     -- ** Validation
     c_phone_number_is_possible_number,
     c_phone_number_is_valid_number,
@@ -48,6 +51,8 @@ data PhoneNumberUtil = PhoneNumberUtil { unPhoneNumberUtil :: Ptr PhoneNumberUti
 {# enum PhoneNumberFormat as PhoneNumberFormat {underscoreToCase} deriving (Eq, Show) #}
 
 {# enum ErrorType as PhoneNumberParseError {underscoreToCase} omit (NO_PARSING_ERROR) deriving (Eq, Show) #}
+
+{# enum CountryCodeSource as CountryCodeSource {underscoreToCase} deriving (Eq, Show) #}
 
 --  | Create a PhoneNumber opaque pointer
 foreign import ccall unsafe "c-phone-numbers.h _c_phone_number_ctor"
@@ -78,6 +83,19 @@ foreign import ccall unsafe "c-phone-numbers.h _c_phone_number_util_parse"
         -- ^ The pointer to write to
         -> IO CInt
 
+-- | Call a C wrapper to parse a phone number with explicit length strings
+foreign import ccall unsafe "c-phone-numbers.h _c_phone_number_util_parse_and_keep_raw_input"
+    c_phone_number_util_parse_and_keep_raw_input
+        :: Ptr PhoneNumberUtil
+        -> CString
+        -> CInt
+        -- ^ The phone number
+        -> CString
+        -> CInt
+        -- ^ The region code (AU, US, etc)
+        -> Ptr PhoneNumberRef
+        -- ^ The pointer to write to
+        -> IO CInt
 
 foreign import ccall unsafe "c-phone-numbers.h _c_phone_number_convert_alpha_characters_in_number"
     c_phone_number_convert_alpha_characters_in_number
@@ -140,3 +158,8 @@ foreign import ccall unsafe "c-phone-numbers.h _c_phone_number_get_formatted"
         -> Ptr PhoneNumberRef
         -> CInt
         -> IO CString
+
+foreign import ccall unsafe "c-phone-numbers.h _c_phone_number_get_country_code_source"
+    c_phone_number_get_country_code_source
+        :: Ptr PhoneNumberRef
+        -> IO CInt


### PR DESCRIPTION
aka whether or not a country code was parsed from the phone number, or inferred.